### PR TITLE
Custom command creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__
 .env
+env/
+*.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 __pycache__
 .env
 env/
-*.json
+.vim/

--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ MAZ Chan is a discord bot for a server. It is built and maintained by members of
 ### Installation
 1. Run `git clone https://github.com/samuelle107/maz-chan.git` at wherever you want to clone it.
 2. Make a .env file at the root of the repository.
-3. Create a `json` file and add it's path to the `.env` file in the environment variable `CUSTOM_COMMANDS_FILE_PATH`
-4. Add the content `DISCORD_BOT_TOKEN=xxx` to line 1. xxx is the bot token. Either ask me for it or make your own bot. Note, if you make your own bot, you need to change the channel IDs in `bot.py`.
-5. Run `pip3 install requirements.txt` to get all of the packages.
-6. Run `python3 bot.py` to start the bot.
+3. Add the content `DISCORD_BOT_TOKEN=xxx` to line 1. xxx is the bot token. Either ask me for it or make your own bot. Note, if you make your own bot, you need to change the channel IDs in `bot.py`. Add `MYSQL_USERNAME`, `MYSQL_PASSWORD`, `MYSQL_HOST`, and `MYSQL_DB` environment variables as well to the `.env` file. 
+4. Run `pip3 install requirements.txt` to get all of the packages.
+5. Run `python3 bot.py` to start the bot.
 
 ## Deployment
 To deploy the code, you need access to push to my Heroku repository. Contact me for more information.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ MAZ Chan is a discord bot for a server. It is built and maintained by members of
 ### Installation
 1. Run `git clone https://github.com/samuelle107/maz-chan.git` at wherever you want to clone it.
 2. Make a .env file at the root of the repository.
-3. Add the content `DISCORD_BOT_TOKEN=xxx` to line 1. xxx is the bot token. Either ask me for it or make your own bot. Note, if you make your own bot, you need to change the channel IDs in `bot.py`.
-4. Run `pip3 install requirements.txt` to get all of the packages.
-5. Run `python3 bot.py` to start the bot.
+3. Create a `json` file and add it's path to the `.env` file in the environment variable `CUSTOM_COMMANDS_FILE_PATH`
+4. Add the content `DISCORD_BOT_TOKEN=xxx` to line 1. xxx is the bot token. Either ask me for it or make your own bot. Note, if you make your own bot, you need to change the channel IDs in `bot.py`.
+5. Run `pip3 install requirements.txt` to get all of the packages.
+6. Run `python3 bot.py` to start the bot.
 
 ## Deployment
 To deploy the code, you need access to push to my Heroku repository. Contact me for more information.

--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,3 @@
-import create_command
 import datetime
 import discord
 import os
@@ -43,23 +42,77 @@ async def on_member_join(member):
     )
 
 
-# Called when message is sent
+# called when any message is sent
+# this event is used to check if custom command is used
 @client.event
 async def on_message(message):
-    # don't respond to ourselves
     if message.author == client.user:
         return
 
     if message.content[0] == "~" and message.content[
             1:] in create_command.CUSTOM_COMMAND_LIST.keys():
-        print(create_command.CUSTOM_COMMAND_LIST)
         await message.channel.send(
             create_command.CUSTOM_COMMAND_LIST[message.content[1:]])
 
 
+# Used to paste copy pasta
+# !egghead
 @client.command()
-async def new_command(ctx, *args):
-    print(f"got command {args[0]}")
+async def egghead(ctx):
+    await ctx.send(
+        "https://media.discordapp.net/attachments/668640100367990793/714849219231613029/unknown.png"
+    )
+
+
+# Used to paste copy pasta
+# !prawn
+@client.command()
+async def prawn(ctx):
+    await ctx.send("ANOTHA PRAWN ON THE BAWBIE")
+
+
+@client.command()
+async def test(ctx):
+    await ctx.send("hello")
+
+
+# Used to clone a message to a different channel
+# !cl <number of messages ago> <#channel>
+@client.command()
+async def cl(ctx, *args):
+    messages_ago = int(args[0]) + 1
+    target_channel_id = int("".join([(s) for s in args[1] if s.isdigit()]))
+
+    channel = client.get_channel(target_channel_id)
+    messages = await ctx.history(limit=messages_ago).flatten()
+    message = f"{messages[-1].author.mention} said: {messages[-1].attachments[0].url if len(messages[-1].attachments) > 0 else messages[-1].content}"
+
+    await channel.send(message)
+
+
+# Used to clone a message by id
+# !clid id <#channel>
+@client.command()
+async def clid(ctx, *args):
+    id = int(args[0])
+    target_channel_id = int("".join([(s) for s in args[1] if s.isdigit()]))
+    channel = client.get_channel(target_channel_id)
+    message_data = await ctx.channel.fetch_message(id)
+
+    message = f"{message_data.author.mention} said: {message_data.attachments[0].url if len(message_data.attachments) > 0 else message_data.content}"
+    await channel.send(message)
+
+
+@client.command()
+async def gugl(ctx, *args):
+    base_url = "https://www.google.com/search?"
+    query = f"q={'+'.join(args)}"
+    await ctx.send(base_url + query)
+
+
+# create a new custom command
+@client.command()
+async def ncc(ctx, *args):
     command_name = args[0]
     if command_name in create_command.CUSTOM_COMMAND_LIST.keys():
         await ctx.send(
@@ -81,16 +134,18 @@ async def new_command(ctx, *args):
     create_command.save_command(command_name, msg.content)
 
 
+# list all custom commands
 @client.command()
-async def list_custom_commands(ctx):
+async def lcc(ctx):
     formatted_string = ""
     for k, v in create_command.CUSTOM_COMMAND_LIST:
         formatted_string += f"`{k}`: `{v}`\n"
     await ctx.send(formatted_string)
 
 
+# remove a custom command
 @client.command()
-async def remove_command(ctx, *args):
+async def rcc(ctx, *args):
     command_name = args[0][1:]
     print(command_name)
     if command_name in create_command.CUSTOM_COMMAND_LIST.keys():
@@ -100,42 +155,4 @@ async def remove_command(ctx, *args):
         await ctx.send(f"No such command `{command_name}`")
 
 
-# Used to paste copy pasta
-# !egghead
-@client.command()
-async def egghead(ctx):
-    await ctx.send(
-        "https://media.discordapp.net/attachments/668640100367990793/714849219231613029/unknown.png"
-    )
-
-
-# Used to paste copy pasta
-# !prawn
-@client.command()
-async def prawn(ctx):
-    await ctx.send("ANOTHA PRAWN ON THE BAWBIE")
-
-
-# Used to clone a message to a different channel
-# !clone <number of messages ago> <#channel>
-@client.command()
-async def clone(ctx, *args):
-    messages_ago = int(args[0]) + 1
-    target_channel_id = int("".join([(s) for s in args[1] if s.isdigit()]))
-
-    channel = client.get_channel(target_channel_id)
-    messages = await ctx.history(limit=messages_ago).flatten()
-    message = f"{messages[-1].author.mention} said: {messages[-1].attachments[0].url if len(messages[-1].attachments) > 0 else messages[-1].content}"
-
-    await channel.send(message)
-
-
-@client.command()
-async def gugl(ctx, *args):
-    base_url = "https://www.google.com/search?"
-    query = f"q={'+'.join(args)}"
-    await ctx.send(base_url + query)
-
-
-create_command.load_commands()
 client.run(DISCORD_BOT_TOKEN)

--- a/bot.py
+++ b/bot.py
@@ -13,11 +13,11 @@ load_dotenv()
 # DISCORD_BOT_TOKEN=xxxx
 DISCORD_BOT_TOKEN = os.environ['DISCORD_BOT_TOKEN']
 # These values are found by right clicking on the channel and then clicking copy ID
-WELCOME_CHANNEL_ID =  744054264640569355
-BOT_COMMANDS_CHANNEL_ID =  744057858886336552
-BOT_TESTING_CHANNEL_ID =  744065526023847957
+WELCOME_CHANNEL_ID = 744054264640569355
+BOT_COMMANDS_CHANNEL_ID = 744057858886336552
+BOT_TESTING_CHANNEL_ID = 744065526023847957
 GENERAL_CHAT_CHANNEL_ID = 744030856196390994
-RULES_CHANNEL_ID =  744047107866099813
+RULES_CHANNEL_ID = 744047107866099813
 
 client = commands.Bot(command_prefix='!')
 
@@ -50,7 +50,8 @@ async def on_message(message):
     if message.author == client.user:
         return
 
-    if message.content[0] == "~" and message.content[1:] in create_command.CUSTOM_COMMAND_LIST.keys():
+    if message.content[0] == "~" and message.content[
+            1:] in create_command.CUSTOM_COMMAND_LIST.keys():
         print(create_command.CUSTOM_COMMAND_LIST)
         await message.channel.send(
             create_command.CUSTOM_COMMAND_LIST[message.content[1:]])
@@ -86,6 +87,7 @@ async def list_custom_commands(ctx):
     for k, v in create_command.CUSTOM_COMMAND_LIST:
         formatted_string += f"`{k}`: `{v}`\n"
     await ctx.send(formatted_string)
+
 
 @client.command()
 async def remove_command(ctx, *args):

--- a/bot.py
+++ b/bot.py
@@ -1,3 +1,4 @@
+import create_command
 import datetime
 import discord
 import os
@@ -12,18 +13,20 @@ load_dotenv()
 # DISCORD_BOT_TOKEN=xxxx
 DISCORD_BOT_TOKEN = os.environ['DISCORD_BOT_TOKEN']
 # These values are found by right clicking on the channel and then clicking copy ID
-WELCOME_CHANNEL_ID = 744054264640569355
-BOT_COMMANDS_CHANNEL_ID = 744057858886336552
-BOT_TESTING_CHANNEL_ID = 744065526023847957
+WELCOME_CHANNEL_ID =  744054264640569355
+BOT_COMMANDS_CHANNEL_ID =  744057858886336552
+BOT_TESTING_CHANNEL_ID =  744065526023847957
 GENERAL_CHAT_CHANNEL_ID = 744030856196390994
-RULES_CHANNEL_ID = 744047107866099813
+RULES_CHANNEL_ID =  744047107866099813
 
 client = commands.Bot(command_prefix='!')
+
 
 @client.event
 async def on_ready():
     channel = client.get_channel(BOT_TESTING_CHANNEL_ID)
     await channel.send("MAZ Chan is ready!")
+
 
 # Called when a new member joins
 # Will add them to a refugee role, send a gif, and message
@@ -35,19 +38,81 @@ async def on_member_join(member):
 
     await member.add_roles(role)
     await channel.send(url)
-    await channel.send(f'Irasshaimase, {member.mention} \n\nRead the rules at <#{RULES_CHANNEL_ID}>')
+    await channel.send(
+        f'Irasshaimase, {member.mention} \n\nRead the rules at <#{RULES_CHANNEL_ID}>'
+    )
+
+
+# Called when message is sent
+@client.event
+async def on_message(message):
+    # don't respond to ourselves
+    if message.author == client.user:
+        return
+
+    if message.content[0] == "~" and message.content[1:] in create_command.CUSTOM_COMMAND_LIST.keys():
+        print(create_command.CUSTOM_COMMAND_LIST)
+        await message.channel.send(
+            create_command.CUSTOM_COMMAND_LIST[message.content[1:]])
+
+
+@client.command()
+async def new_command(ctx, *args):
+    print(f"got command {args[0]}")
+    command_name = args[0]
+    if command_name in create_command.CUSTOM_COMMAND_LIST.keys():
+        await ctx.send(
+            f"`{command_name}` already exists. Are you sure you want to continue (y/n)"
+        )
+        msg = await client.wait_for(
+            'message',
+            check=lambda m: m.author == ctx.author and m.channel == ctx.channel
+            and m.content in ['y', 'n'])
+        if msg.content == 'n':
+            await ctx.send("**Aborting...**")
+            return
+    await ctx.send(
+        f"please enter the text the command `{command_name}` should display when it is called"
+    )
+    msg = await client.wait_for(
+        'message',
+        check=lambda m: m.author == ctx.author and m.channel == ctx.channel)
+    create_command.save_command(command_name, msg.content)
+
+
+@client.command()
+async def list_custom_commands(ctx):
+    formatted_string = ""
+    for k, v in create_command.CUSTOM_COMMAND_LIST:
+        formatted_string += f"`{k}`: `{v}`\n"
+    await ctx.send(formatted_string)
+
+@client.command()
+async def remove_command(ctx, *args):
+    command_name = args[0][1:]
+    print(command_name)
+    if command_name in create_command.CUSTOM_COMMAND_LIST.keys():
+        create_command.remove_command(command_name)
+        await ctx.send(f"Successfully deleted command `{command_name}`")
+    else:
+        await ctx.send(f"No such command `{command_name}`")
+
 
 # Used to paste copy pasta
 # !egghead
 @client.command()
 async def egghead(ctx):
-    await ctx.send("https://media.discordapp.net/attachments/668640100367990793/714849219231613029/unknown.png")
+    await ctx.send(
+        "https://media.discordapp.net/attachments/668640100367990793/714849219231613029/unknown.png"
+    )
+
 
 # Used to paste copy pasta
 # !prawn
 @client.command()
 async def prawn(ctx):
     await ctx.send("ANOTHA PRAWN ON THE BAWBIE")
+
 
 # Used to clone a message to a different channel
 # !clone <number of messages ago> <#channel>
@@ -69,4 +134,6 @@ async def gugl(ctx, *args):
     query = f"q={'+'.join(args)}"
     await ctx.send(base_url + query)
 
+
+create_command.load_commands()
 client.run(DISCORD_BOT_TOKEN)

--- a/create_command.py
+++ b/create_command.py
@@ -1,33 +1,48 @@
 import discord
 import os
 import json
+import mysql.connector
 from discord.ext import commands
 from dotenv import load_dotenv
 
 if __name__ == "__main__":
     load_dotenv()
 
+con = mysql.connector.connect(user=os.getenv("MYSQL_USERNAME"),
+                              password=os.getenv("MYSQL_PASSWORD"),
+                              host=os.getenv("MYSQL_HOST"),
+                              database=os.getenv("MYSQL_DB"),
+                              charset="utf8",
+                              use_unicode=True)
 CUSTOM_COMMAND_LIST = dict()
 
 
-# create CUSTOM_COMMANDS_FILE_PATH variable in .env file
 def load_commands() -> str:
     global CUSTOM_COMMAND_LIST
-    with open(os.getenv("CUSTOM_COMMANDS_FILE_PATH"), "r") as f:
-        CUSTOM_COMMAND_LIST = json.load(f)
+    cur = con.cursor()
+    sql = "SELECT (command, command_text) FROM custom_commands"
+    cur.execute(sql)
+    custom_commands = cur.fetchall()
+    for (command, command_text) in custom_commands:
+        CUSTOM_COMMAND_LIST[command] = command_text
+    cur.close()
     return CUSTOM_COMMAND_LIST
 
 
 def save_command(command: str, text: str):
     global CUSTOM_COMMAND_LIST
     CUSTOM_COMMAND_LIST[command] = text
-    with open(os.getenv("CUSTOM_COMMANDS_FILE_PATH"), "w") as f:
-        json.dump(CUSTOM_COMMAND_LIST, f)
+    cur = con.cursor()
+    sql = f"INSERT INTO custom_commands (command, command_text) VALUES ({command}, {text})"
+    cur.execute(sql)
+    cur.close()
 
 
 def remove_command(command: str) -> str:
     global CUSTOM_COMMAND_LIST
     del CUSTOM_COMMAND_LIST[command]
-    with open(os.getenv("CUSTOM_COMMANDS_FILE_PATH"), "w") as f:
-        json.dump(CUSTOM_COMMAND_LIST, f)
+    cur = con.cursor()
+    sql = f"DELETE FROM custom_commands WHERE command = '{command}'"
+    cur.execute(sql)
+    cur.close()
     return command

--- a/create_command.py
+++ b/create_command.py
@@ -1,0 +1,33 @@
+import discord
+import os
+import json
+from discord.ext import commands
+from dotenv import load_dotenv
+
+if __name__ == "__main__":
+    load_dotenv()
+
+CUSTOM_COMMAND_LIST = dict()
+
+
+# create CUSTOM_COMMANDS_FILE_PATH variable in .env file
+def load_commands() -> str:
+    global CUSTOM_COMMAND_LIST
+    with open(os.getenv("CUSTOM_COMMANDS_FILE_PATH"), "r") as f:
+        CUSTOM_COMMAND_LIST = json.load(f)
+    return CUSTOM_COMMAND_LIST
+
+
+def save_command(command: str, text: str):
+    global CUSTOM_COMMAND_LIST
+    CUSTOM_COMMAND_LIST[command] = text
+    with open(os.getenv("CUSTOM_COMMANDS_FILE_PATH"), "w") as f:
+        json.dump(CUSTOM_COMMAND_LIST, f)
+
+
+def remove_command(command: str) -> str:
+    global CUSTOM_COMMAND_LIST
+    del CUSTOM_COMMAND_LIST[command]
+    with open(os.getenv("CUSTOM_COMMANDS_FILE_PATH"), "w") as f:
+        json.dump(CUSTOM_COMMAND_LIST, f)
+    return command

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 discord.py==1.3.4
 python-dotenv==0.13.0
+mysql-connector-python==8.0.21


### PR DESCRIPTION
You can create custom commands by typing `!new_command <command name>`.  After the user enters this command, they are prompted to enter a phrase that is displayed when that command is run. The custom command can be run by typing `~<command name>`. `!list_custom_commands` lists all custom commands and `!remove_command <command name>` removes a specified command.